### PR TITLE
MYFACES-4430 - Separate "begin tag" code from "end tag" code in HtmlCheckboxRendererBase


### DIFF
--- a/shared/src/main/java/org/apache/myfaces/shared/renderkit/html/HtmlCheckboxRendererBase.java
+++ b/shared/src/main/java/org/apache/myfaces/shared/renderkit/html/HtmlCheckboxRendererBase.java
@@ -54,7 +54,8 @@ public class HtmlCheckboxRendererBase extends HtmlRenderer
 
     private static final String EXTERNAL_TRUE_VALUE = "true";
 
-    public void encodeEnd(FacesContext facesContext, UIComponent uiComponent)
+    @Override
+    public void encodeBegin(FacesContext facesContext, UIComponent uiComponent)
             throws IOException
     {
         org.apache.myfaces.shared.renderkit.RendererUtils.checkParamValidity(facesContext, uiComponent, null);
@@ -78,12 +79,32 @@ public class HtmlCheckboxRendererBase extends HtmlRenderer
         }
         else if (uiComponent instanceof UISelectMany)
         {
-            renderCheckboxList(facesContext, (UISelectMany) uiComponent);
+            // let the current impl do what it does in encodeEnd do nothing here just don't want exception
+            // throw if it is this case
+            log.finest("encodeBegin() doing nothing intentionally for UISelectMany");
         }
         else
         {
             throw new IllegalArgumentException("Unsupported component class "
                     + uiComponent.getClass().getName());
+        }
+    }
+    
+    @Override
+    public void encodeEnd(FacesContext facesContext, UIComponent uiComponent) throws IOException
+    {
+        if (uiComponent instanceof UISelectBoolean)
+        {
+            ResponseWriter writer = facesContext.getResponseWriter();
+            writer.endElement(HTML.INPUT_ELEM);
+        }
+        else if (uiComponent instanceof UISelectMany)
+        {
+            renderCheckboxList(facesContext, (UISelectMany) uiComponent);
+        }
+        else
+        {
+            throw new IllegalArgumentException("Unsupported component class " + uiComponent.getClass().getName());
         }
     }
 
@@ -466,7 +487,10 @@ public class HtmlCheckboxRendererBase extends HtmlRenderer
             writer.writeAttribute(HTML.DISABLED_ATTR, HTML.DISABLED_ATTR, null);
         }
         
-        writer.endElement(HTML.INPUT_ELEM);
+        if (uiComponent instanceof UISelectMany)
+        {
+            writer.endElement(HTML.INPUT_ELEM);
+        }
 
         return itemId;
     }


### PR DESCRIPTION
JSF provides a encodeBegin() and an encodeEnd() method on a Renderer. MyFaces currently performs "begin tag" and "end tag" encoding in the encodeEnd(), which breaks any vendor-neutral path for extensibility. This patch moves the "begin tag" encoding logic to the encodeBegin() function so the renderkit can be extended without needed to extend myfaces classes explicitly, but instead be called through the standard JSF api to start a tag.